### PR TITLE
Updated some auto layout properties for activity indicator.

### DIFF
--- a/templates/ios/9.0/ios_helper_implementation.mustache
+++ b/templates/ios/9.0/ios_helper_implementation.mustache
@@ -56,8 +56,8 @@
 
 - (UIView *) loadingViewForTasks {
 	CGRect screenRect = [[UIScreen mainScreen] bounds];
-	CGFloat screenWidth = screenRect.size.width;
-	CGFloat screenHeight = screenRect.size.height;
+    CGFloat screenWidth = screenRect.size.width;
+    CGFloat screenHeight = screenRect.size.height;
     
     UIView *loadingView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, screenWidth, screenHeight)];
     [loadingView setBackgroundColor:[UIColor clearColor]];
@@ -78,10 +78,13 @@
     [activityIndicator setFrame:CGRectMake(screenWidth/2 - activityIndicator.frame.size.width/2,       // X
                                            screenHeight/2 - activityIndicator.frame.size.height/2,     // Y
                                            activityIndicator.frame.size.width, activityIndicator.frame.size.height)];
+    centerView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     [loadingView addSubview:centerView];
+    activityIndicator.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
     [loadingView addSubview:activityIndicator];    
     [activityIndicator startAnimating];
     
+    loadingView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     return loadingView;
 }
 


### PR DESCRIPTION
Hi guys! I just made a change on the ios template.

I found  a bug on the activity indicator view used to indicate a task is running. The position of the indicator was not centered when it is shown and the device is rotating.

- So I just added some auto layout properties ( thanks Murillo =) ) to avoid this bug and show the indicator view centered whatever happens.

Feel free to take a look =) because Im not sure if I need to add a new template or a did it right modifying the last one.

Tnaks in advance!!!
@drmillan @alvaromurillo @awayo @luismacb @kiko @juanmatm82 